### PR TITLE
Revert "Drop nxp Android.bp"

### DIFF
--- a/custom.xml
+++ b/custom.xml
@@ -47,6 +47,7 @@
     <linkfile src="os_pickup.mk" dest="hardware/qcom-caf/sm8250/Android.mk" />
     <linkfile src="os_pickup_qssi.bp" dest="hardware/qcom-caf/sm8350/Android.bp" />
     <linkfile src="os_pickup.mk" dest="hardware/qcom-caf/sm8350/Android.mk" />
+    <linkfile src="os_pickup.bp" dest="hardware/nxp/Android.bp" />
     <linkfile src="os_pickup.bp" dest="vendor/nxp/opensource/pn5xx/Android.bp" />
     <linkfile src="os_pickup.mk" dest="vendor/nxp/opensource/pn5xx/Android.mk" />
     <linkfile src="os_pickup.bp" dest="vendor/nxp/opensource/sn100x/Android.bp" />


### PR DESCRIPTION
* error: vendor/nxp/opensource/sn100x/halimpl/SN100x/halimpl/libnxpparser: MODULE.TARGET.SHARED_LIBRARIES.nxp_nci_parser already defined by hardware/nxp/nfc/snxxx/halimpl/libnxpparser when using vendor/nxp/opensource

This reverts commit 5c8401ad1b3d28fad12898b96712b7997b126a86.

Change-Id: Ib7131daa8a5537d69376f27404ce5e305dc068a8